### PR TITLE
cpp: simple queue example

### DIFF
--- a/cpp_queue/CMakeLists.txt
+++ b/cpp_queue/CMakeLists.txt
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Intel Corporation nor the names of its contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required(VERSION 3.1.0)
+project(cpp_queue VERSION 0.0.1)
+
+set (CMAKE_CXX_STANDARD 11)
+include_directories(/usr/local/include)
+add_executable(cpp_queue main.cpp volatile_queue.cpp persistent_queue.cpp)
+
+target_link_libraries(cpp_queue pmemobj)

--- a/cpp_queue/Makefile
+++ b/cpp_queue/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Intel Corporation nor the names of its contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+PROGS = cpp_queue
+
+override CXXFLAGS += `pkg-config --cflags libpmemobj++` -I./ -std=c++11
+override LDFLAGS += `pkg-config --libs libpmemobj++` -lpthread
+
+OBJS = main.o
+HEAD =
+#HEAD = pm_mapreduce.hpp task_list.hpp list_entry.hpp helpers.hpp persistent_string.hpp
+
+%.o : %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+all: $(PROGS)
+
+cpp_queue: $(OBJS) $(HEAD)
+	$(CXX) $(OBJS) $(LDFLAGS) -o $@
+
+clean:
+	$(RM) $(OBJS) $(PROGS)

--- a/cpp_queue/README.md
+++ b/cpp_queue/README.md
@@ -1,0 +1,80 @@
+### Introduction
+
+This is an implementation of a very simple queue with a singly linked list as
+the backing data structure. This example contains two implementations,
+a normal, volatile queue and a persistent memory resident version with an
+identical API. The purpose of this example is to show what kind of effort is
+needed to convert existing applications. **NOTE:** this implementation in not
+optimal, it is meant to be an illustration not a robust, high performing
+implementation. 
+
+### Build Instructions
+
+There is a Makefile provided by the sample. To compile the sample, just type
+`make`; NVML (libpmemobj is part of NVML) needs to be properly installed in
+your system, as well as a C++ compiler. The default C++ compiler used is `g++`.
+You can change that by setting the `CXX` variable in the Makefile.
+
+If compilation fails because pkg-config cannot find the configuration files
+for NVML, you may need to set the `PKG_CONFIG_PATH` variable before doing make.
+If you installed NVML with the default configuration, these files will probably
+be either in `/usr/local/lib/pkgconfig` or `/usr/local/lib64/pkgconfig`.
+
+```bash
+$ export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:$PKG_CONFIG_PATH
+```
+
+There is also a rudimentary CMakeLists.txt file provided for convenience.
+
+### How to Run
+
+After compilation, you can run the program without parameters to get usage help:
+
+```
+$ ./cpp_queue
+usage: ./cpp_queue [v | p] file-name [push [value]|pop|show]
+```
+
+The `[v | p]` stands for *volatile*/*persistent*. The binary contains both the
+volatile and persistent implementation. The contents of the volatile version
+do not however survive between application runs. It is however provided should
+the user wish to modify the implementation to experiment.
+
+To run the persistent queue and push some initial value into it execute:
+
+```
+$ ./cpp_queue p /mnt/pmem/pqueue.pool push 1
+```
+
+This will create a pqueue.pool file in the /mnt/pmem directory and push the value
+1 into the queue. This can be repeated a number of times to populate the queue with
+data.
+
+To print the contents of the queue run:
+
+```
+$ ./cpp_queue p /mnt/pmem/pqueue.pool show
+1
+12
+123
+1234
+12345
+123456
+1234567
+12345678
+123456789
+1
+```
+
+To pop the first value from the queue:
+
+```
+$ ./cpp_queue p /mnt/pmem/pqueue.pool pop
+1
+```
+
+### Final Note
+
+The reader is encouraged to play with the implementation and check different scenarios
+like inserting values in a loop, randomly crashing the application and checking whether
+it is possible to print the queue.

--- a/cpp_queue/main.cpp
+++ b/cpp_queue/main.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "libpmemobj++/make_persistent_atomic.hpp"
+#include "persistent_queue.hpp"
+#include "volatile_queue.hpp"
+
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#ifndef _WIN32
+
+#include <unistd.h>
+#define CREATE_MODE_RW (S_IWUSR | S_IRUSR)
+
+#else
+
+#include <io.h>
+#define CREATE_MODE_RW (S_IWRITE | S_IREAD)
+
+#endif
+
+namespace
+{
+
+/* The layout string */
+const char *LAYOUT = "queue";
+
+/* Available queue operations */
+enum queue_op {
+	UNKNOWN_QUEUE_OP,
+	QUEUE_PUSH,
+	QUEUE_POP,
+	QUEUE_SHOW,
+
+	MAX_QUEUE_OP
+};
+
+/* Queue operations strings */
+std::string ops_str[queue_op::MAX_QUEUE_OP] = {"", "push", "pop", "show"};
+
+/*
+ * parse_queue_op -- parses the operation string and returns matching queue_op
+ */
+queue_op
+parse_queue_op(const char *str)
+{
+
+	for (int i = 0; i < queue_op::MAX_QUEUE_OP; ++i)
+		if (ops_str[i] == str)
+			return static_cast<queue_op>(i);
+
+	return queue_op::UNKNOWN_QUEUE_OP;
+}
+
+/*
+ * file_exists -- checks whether the given file exists
+ */
+bool
+file_exists(const std::string &path)
+{
+	std::ifstream f(path.c_str());
+	return f.good();
+}
+
+/*
+ * handle_op -- handles the requested queue operation
+ */
+template <typename T>
+void
+handle_op(T &queue, queue_op op, std::function<long long int()> val)
+{
+	switch (op) {
+		case QUEUE_PUSH:
+			queue->push(val());
+			break;
+		case QUEUE_POP:
+			std::cout << queue->pop() << std::endl;
+			break;
+		case QUEUE_SHOW:
+			std::cout << queue->show();
+			break;
+		default:
+			throw std::invalid_argument("invalid queue operation");
+			break;
+	}
+}
+
+/* The root object definition */
+struct root {
+	nvml::obj::persistent_ptr<nvml::examples::PersistentQueue> pqueue;
+	nvml::examples::VolatileQueue *vqueue;
+};
+}
+
+int
+main(int argc, char *argv[])
+{
+	if (argc < 4) {
+		std::cerr << "usage: " << argv[0]
+			  << " [v | p] file-name [push [value]|pop|show]"
+			  << std::endl;
+		return 1;
+	}
+
+	std::string path{argv[2]};
+	auto op = parse_queue_op(argv[3]);
+
+	/* handle file creation/open */
+	nvml::obj::pool<root> pop;
+	if (file_exists(path)) {
+		pop = nvml::obj::pool<root>::open(path, LAYOUT);
+	} else {
+		pop = nvml::obj::pool<root>::create(
+			path, LAYOUT, PMEMOBJ_MIN_POOL * 20, CREATE_MODE_RW);
+
+		/* allocate the persistent queue only when the pool is new */
+		nvml::obj::make_persistent_atomic<
+			nvml::examples::PersistentQueue>(
+			pop, pop.get_root()->pqueue);
+	}
+
+	/* get the root object pointer */
+	auto proot = pop.get_root();
+
+	/* always allocate the volatile queue */
+	proot->vqueue = new nvml::examples::VolatileQueue();
+
+	/* lambda get value for push operation */
+	auto value = [&argv]() -> long long int { return atoll(argv[4]); };
+
+	std::string type{argv[1]};
+	if (type == "v")
+		handle_op(proot->vqueue, op, value);
+	else if (type == "p")
+		handle_op(proot->pqueue, op, value);
+	else
+		throw std::runtime_error(
+			std::string{"Unknown queue type selected"} += type);
+
+	pop.close();
+
+	return 0;
+}

--- a/cpp_queue/persistent_queue.cpp
+++ b/cpp_queue/persistent_queue.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "persistent_queue.hpp"
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/transaction.hpp>
+#include <libpmemobj++/utils.hpp>
+
+#include <sstream>
+#include <exception>
+
+namespace nvml
+{
+
+namespace examples
+{
+
+void
+PersistentQueue::push(long long int value)
+{
+	auto pool = nvml::obj::pool_by_vptr(this);
+	obj::transaction::exec_tx(pool, [this, &value] {
+		auto n = obj::make_persistent<Node>(value, nullptr);
+
+		if (head == nullptr) {
+			head = tail = n;
+		} else {
+			tail->next = n;
+			tail = n;
+		}
+	});
+}
+
+long long int
+PersistentQueue::pop()
+{
+	long long int ret = 0;
+	auto pool = nvml::obj::pool_by_vptr(this);
+	obj::transaction::exec_tx(pool, [this, &ret] {
+		if (head == nullptr)
+			throw std::runtime_error("Nothing to pop");
+
+		ret = head->value;
+		auto n = head->next;
+
+		obj::delete_persistent<Node>(head);
+		head = n;
+
+		if (head == nullptr)
+			tail = nullptr;
+	});
+
+	return ret;
+}
+
+std::string
+PersistentQueue::show(void) const
+{
+	std::stringstream ss;
+	for (auto n = head; n != nullptr; n = n->next)
+		ss << n->value << "\n";
+
+	return ss.str();
+}
+
+} // namespace examples
+} // namespace nvml

--- a/cpp_queue/persistent_queue.hpp
+++ b/cpp_queue/persistent_queue.hpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <libpmemobj++/p.hpp>
+#include <libpmemobj++/persistent_ptr.hpp>
+
+#include <utility>
+
+namespace nvml
+{
+
+namespace examples
+{
+
+/*!
+ * \brief Persistent memory list-based queue.
+ *
+ * A simple, not template based, implementation of a queue using
+ * libpmemobj C++ API. It demonstrates the basic features of persistent_ptr<>
+ * and p<> classes.
+ */
+class PersistentQueue {
+public:
+	/*!
+	 * \brief Inserts a new element at the end of the queue.
+	 *
+	 * \param value the value to be pushed to the end of the queue.
+	 */
+	void push(long long int value);
+
+	/*!
+	 * \brief Removes the first element in the queue.
+	 *
+	 * \return the first element in the queue.
+	 */
+	long long int pop();
+
+	/*!
+	 * \brief Prints the entire contents of the queue.
+	 *
+	 * \return a string representation of the queue.
+	 */
+	std::string show(void) const;
+
+private:
+	/*!
+	 * \brief Internal node definition.
+	 */
+	struct Node {
+
+		/*!
+		 * \brief Constructor.
+		 *
+		 * \param val the value held by this node.
+		 * \param n the next node in the queue.
+		 */
+		Node(long long int val, obj::persistent_ptr<Node> n)
+		    : next(std::move(n)), value(std::move(val))
+		{
+		}
+
+		/* Pointer to the next node */
+		obj::persistent_ptr<Node> next;
+		/* Value held by this node */
+		obj::p<long long int> value;
+	};
+
+	/* The head of the queue */
+	obj::persistent_ptr<Node> head;
+	/* The tail of the queue */
+	obj::persistent_ptr<Node> tail;
+};
+
+} // namespace examples
+} // namespace nvml

--- a/cpp_queue/volatile_queue.cpp
+++ b/cpp_queue/volatile_queue.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "volatile_queue.hpp"
+
+#include <sstream>
+#include <stdexcept>
+
+namespace nvml
+{
+namespace examples
+{
+
+void
+VolatileQueue::push(long long int value)
+{
+	auto n = std::make_shared<Node>(value, nullptr);
+
+	if (head == nullptr) {
+		head = tail = n;
+	} else {
+		tail->next = n;
+		tail = n;
+	}
+}
+
+long long int
+VolatileQueue::pop()
+{
+	if (head == nullptr)
+		throw std::runtime_error("Nothing to pop");
+
+	auto ret = head->value;
+	head = head->next;
+
+	if (head == nullptr)
+		tail = nullptr;
+
+	return ret;
+}
+
+std::string
+VolatileQueue::show(void) const
+{
+	std::stringstream ss;
+	for (auto n = head; n != nullptr; n = n->next)
+		ss << n->value << "\n";
+
+	return ss.str();
+}
+
+} // namespace examples
+} // namespace nvml

--- a/cpp_queue/volatile_queue.hpp
+++ b/cpp_queue/volatile_queue.hpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+#include <utility>
+
+namespace nvml
+{
+namespace examples
+{
+
+/*!
+ * \brief A simple list-based queue.
+ *
+ * A simple, not template based, implementation of a queue.
+ */
+class VolatileQueue {
+public:
+	/*!
+	 * \brief Inserts a new element at the end of the queue.
+	 *
+	 * \param value the value to be pushed to the end of the queue.
+	 */
+	void push(long long int value);
+
+	/*!
+	 * \brief Removes the first element in the queue.
+	 *
+	 * \return the first element in the queue.
+	 */
+	long long int pop();
+
+	/*!
+	 * \brief Prints the entire contents of the queue.
+	 *
+	 * \return a string representation of the queue.
+	 */
+	std::string show(void) const;
+
+private:
+	/*!
+	 * \brief Internal node definition.
+	 */
+	struct Node {
+
+		/*!
+		 * \brief Constructor.
+		 *
+		 * \param val the value held by this node.
+		 * \param n the next node in the queue.
+		 */
+		Node(long long int val, std::shared_ptr<Node> n)
+		    : next(std::move(n)), value(std::move(val))
+		{
+		}
+
+		/* Pointer to the next node */
+		std::shared_ptr<Node> next;
+		/* Value held by this node */
+		long long int value;
+	};
+
+	/* The head of the queue */
+	std::shared_ptr<Node> head;
+	/* The tail of the queue */
+	std::shared_ptr<Node> tail;
+};
+
+} // namespace examples
+} // namespace nvml


### PR DESCRIPTION
This is a simple implementation of a volatile queue and a matching
persistent memory resident version of the same queue.

It is very similar to the example in the NVML tree, however it serves a different purpose, showing how to get from a volatile implementation to a persistent one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml-examples/2)
<!-- Reviewable:end -->
